### PR TITLE
[Feat] 카카오 로그인 및 회원가입 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,11 +45,20 @@ dependencies {
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    // JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
     // Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
+
+    //JJWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/umc/timeto/auth/client/KakaoClient.java
+++ b/src/main/java/com/umc/timeto/auth/client/KakaoClient.java
@@ -1,4 +1,118 @@
 package com.umc.timeto.auth.client;
 
+import com.umc.timeto.auth.dto.kakao.KakaoMeResponse;
+import com.umc.timeto.auth.dto.kakao.KakaoTokenResponse;
+import com.umc.timeto.auth.dto.kakao.KakaoUserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+//카카오 서버와 직접 통신해서 인가코드 → 사용자 정보를 가져오는 외부 API 전용 클라이언트
+@Component
+@RequiredArgsConstructor
 public class KakaoClient {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${kakao.client-id}")
+    private String clientId;
+
+    @Value("${kakao.client-secret:}")
+    private String clientSecret;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    // [기능] 인가코드로 카카오 access token 발급
+    public String getAccessToken(String authorizationCode) {
+        String tokenUrl = "https://kauth.kakao.com/oauth/token";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("grant_type", "authorization_code");
+        formData.add("client_id", clientId);
+        formData.add("redirect_uri", redirectUri);
+        formData.add("code", authorizationCode);
+
+        if (clientSecret != null && !clientSecret.isBlank()) {
+            formData.add("client_secret", clientSecret);
+        }
+
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(formData, headers);
+
+        ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(
+                tokenUrl,
+                HttpMethod.POST,
+                requestEntity,
+                KakaoTokenResponse.class
+        );
+
+        if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+            throw new IllegalStateException("카카오 토큰 발급 실패");
+        }
+
+        String accessToken = response.getBody().getAccessToken();
+        if (accessToken == null || accessToken.isBlank()) {
+            throw new IllegalStateException("카카오 access_token 응답 누락");
+        }
+
+        return accessToken;
+    }
+
+    // [기능] 카카오 access token으로 사용자 정보 조회
+    public KakaoUserInfo getUserInfo(String kakaoAccessToken) {
+        String meUrl = "https://kapi.kakao.com/v2/user/me";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(kakaoAccessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
+
+        ResponseEntity<KakaoMeResponse> response = restTemplate.exchange(
+                meUrl,
+                HttpMethod.GET,
+                requestEntity,
+                KakaoMeResponse.class
+        );
+
+        if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+            throw new IllegalStateException("카카오 유저 조회 실패");
+        }
+
+        KakaoMeResponse body = response.getBody();
+
+        Long kakaoId = body.getId();
+        if (kakaoId == null) {
+            throw new IllegalStateException("카카오 id 응답 누락");
+        }
+
+        String email = null;
+        String nickname = null;
+
+        if (body.getKakaoAccount() != null) {
+            email = body.getKakaoAccount().getEmail();
+
+            if (body.getKakaoAccount().getProfile() != null) {
+                nickname = body.getKakaoAccount().getProfile().getNickname();
+            }
+        }
+
+        // 이메일은 카카오 동의/설정에 따라 null 가능 → 임시 이메일 처리
+        if (email == null || email.isBlank()) {
+            email = "kakao_" + kakaoId + "@kakao.local";
+        }
+
+        if (nickname == null || nickname.isBlank()) {
+            nickname = "kakaoUser";
+        }
+
+        return new KakaoUserInfo(kakaoId, email, nickname);
+    }
 }

--- a/src/main/java/com/umc/timeto/auth/client/KakaoClient.java
+++ b/src/main/java/com/umc/timeto/auth/client/KakaoClient.java
@@ -1,0 +1,4 @@
+package com.umc.timeto.auth.client;
+
+public class KakaoClient {
+}

--- a/src/main/java/com/umc/timeto/auth/client/KakaoClient.java
+++ b/src/main/java/com/umc/timeto/auth/client/KakaoClient.java
@@ -27,7 +27,7 @@ public class KakaoClient {
     @Value("${kakao.redirect-uri}")
     private String redirectUri;
 
-    // [기능] 인가코드로 카카오 access token 발급
+    // 인가코드로 카카오 access token 발급
     public String getAccessToken(String authorizationCode) {
         String tokenUrl = "https://kauth.kakao.com/oauth/token";
 
@@ -65,7 +65,7 @@ public class KakaoClient {
         return accessToken;
     }
 
-    // [기능] 카카오 access token으로 사용자 정보 조회
+    // 카카오 access token으로 사용자 정보 조회
     public KakaoUserInfo getUserInfo(String kakaoAccessToken) {
         String meUrl = "https://kapi.kakao.com/v2/user/me";
 

--- a/src/main/java/com/umc/timeto/auth/controller/AuthController.java
+++ b/src/main/java/com/umc/timeto/auth/controller/AuthController.java
@@ -1,4 +1,43 @@
 package com.umc.timeto.auth.controller;
 
+import com.umc.timeto.auth.dto.KakaoLoginRequest;
+import com.umc.timeto.auth.dto.KakaoLoginResponse;
+import com.umc.timeto.auth.service.AuthService;
+import com.umc.timeto.global.apiPayload.code.ResponseCode;
+import com.umc.timeto.global.apiPayload.dto.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
 public class AuthController {
+
+    private final AuthService authService;
+
+    // 카카오 로그인
+    @PostMapping("/kakao/login")
+    public ResponseEntity<ResponseDTO<KakaoLoginResponse>> kakaoLogin(
+            @RequestBody KakaoLoginRequest request
+    ) {
+        if (request.getAuthorizationCode() == null ||
+                request.getAuthorizationCode().isBlank()) {
+
+            return ResponseEntity
+                    .status(ResponseCode.COMMON400.getStatus())
+                    .body(new ResponseDTO<>(ResponseCode.COMMON400));
+        }
+
+        AuthService.LoginResult result =
+                authService.kakaoLogin(request.getAuthorizationCode());
+
+        ResponseCode responseCode = result.isNewMember()
+                ? ResponseCode.COMMON201
+                : ResponseCode.COMMON200;
+
+        return ResponseEntity
+                .status(responseCode.getStatus())
+                .body(new ResponseDTO<>(responseCode, result.response()));
+    }
 }

--- a/src/main/java/com/umc/timeto/auth/controller/AuthController.java
+++ b/src/main/java/com/umc/timeto/auth/controller/AuthController.java
@@ -1,0 +1,4 @@
+package com.umc.timeto.auth.controller;
+
+public class AuthController {
+}

--- a/src/main/java/com/umc/timeto/auth/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/umc/timeto/auth/dto/KakaoLoginRequest.java
@@ -1,0 +1,4 @@
+package com.umc.timeto.auth.dto;
+
+public class KakaoLoginRequest {
+}

--- a/src/main/java/com/umc/timeto/auth/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/umc/timeto/auth/dto/KakaoLoginRequest.java
@@ -1,4 +1,11 @@
 package com.umc.timeto.auth.dto;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 서비스의 카카오 로그인 요청(인가코드)을 받기 위한 DTO
+@Getter
+@NoArgsConstructor
 public class KakaoLoginRequest {
+    private String authorizationCode;
 }

--- a/src/main/java/com/umc/timeto/auth/dto/KakaoLoginResponse.java
+++ b/src/main/java/com/umc/timeto/auth/dto/KakaoLoginResponse.java
@@ -1,4 +1,13 @@
 package com.umc.timeto.auth.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// 카카오 로그인 성공 시 서비스에서 발급한 토큰 정보를 담은 응답 DTO
+@Getter
+@AllArgsConstructor
 public class KakaoLoginResponse {
+    private Long memberId;
+    private String accessToken;
+    private String refreshToken;
 }

--- a/src/main/java/com/umc/timeto/auth/dto/KakaoLoginResponse.java
+++ b/src/main/java/com/umc/timeto/auth/dto/KakaoLoginResponse.java
@@ -1,5 +1,6 @@
 package com.umc.timeto.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,7 +8,18 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class KakaoLoginResponse {
+    @Schema(description = "회원 ID", example = "1")
     private Long memberId;
+
+    @Schema(
+            description = "JWT 액세스 토큰",
+            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+    )
     private String accessToken;
+
+    @Schema(
+            description = "JWT 리프레시 토큰",
+            example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+    )
     private String refreshToken;
 }

--- a/src/main/java/com/umc/timeto/auth/dto/KakaoLoginResponse.java
+++ b/src/main/java/com/umc/timeto/auth/dto/KakaoLoginResponse.java
@@ -1,0 +1,4 @@
+package com.umc.timeto.auth.dto;
+
+public class KakaoLoginResponse {
+}

--- a/src/main/java/com/umc/timeto/auth/dto/kakao/KakaoAccount.java
+++ b/src/main/java/com/umc/timeto/auth/dto/kakao/KakaoAccount.java
@@ -1,0 +1,4 @@
+package com.umc.timeto.auth.dto.kakao;
+
+public class KakaoAccount {
+}

--- a/src/main/java/com/umc/timeto/auth/dto/kakao/KakaoAccount.java
+++ b/src/main/java/com/umc/timeto/auth/dto/kakao/KakaoAccount.java
@@ -1,4 +1,13 @@
 package com.umc.timeto.auth.dto.kakao;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+
+// 카카오 사용자 계정 정보를 담는 응답 DTO
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KakaoAccount {
+
+    private String email;
+    private KakaoProfile profile;
 }

--- a/src/main/java/com/umc/timeto/auth/dto/kakao/KakaoMeResponse.java
+++ b/src/main/java/com/umc/timeto/auth/dto/kakao/KakaoMeResponse.java
@@ -1,0 +1,4 @@
+package com.umc.timeto.auth.dto.kakao;
+
+public class KakaoMeResponse {
+}

--- a/src/main/java/com/umc/timeto/auth/dto/kakao/KakaoMeResponse.java
+++ b/src/main/java/com/umc/timeto/auth/dto/kakao/KakaoMeResponse.java
@@ -1,4 +1,16 @@
 package com.umc.timeto.auth.dto.kakao;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+// 카카오 사용자 조회 API의 전체 응답을 매핑하는 DTO
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KakaoMeResponse {
+
+    private Long id;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
 }

--- a/src/main/java/com/umc/timeto/auth/dto/kakao/KakaoProfile.java
+++ b/src/main/java/com/umc/timeto/auth/dto/kakao/KakaoProfile.java
@@ -1,4 +1,10 @@
 package com.umc.timeto.auth.dto.kakao;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KakaoProfile {
+    private String nickname;
 }

--- a/src/main/java/com/umc/timeto/auth/dto/kakao/KakaoProfile.java
+++ b/src/main/java/com/umc/timeto/auth/dto/kakao/KakaoProfile.java
@@ -1,0 +1,4 @@
+package com.umc.timeto.auth.dto.kakao;
+
+public class KakaoProfile {
+}

--- a/src/main/java/com/umc/timeto/auth/dto/kakao/KakaoTokenResponse.java
+++ b/src/main/java/com/umc/timeto/auth/dto/kakao/KakaoTokenResponse.java
@@ -1,0 +1,4 @@
+package com.umc.timeto.auth.dto.kakao;
+
+public class KakaoTokenResponse {
+}

--- a/src/main/java/com/umc/timeto/auth/dto/kakao/KakaoTokenResponse.java
+++ b/src/main/java/com/umc/timeto/auth/dto/kakao/KakaoTokenResponse.java
@@ -1,4 +1,14 @@
 package com.umc.timeto.auth.dto.kakao;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+// 카카오 인가코드로 발급받은 access token 응답을 매핑하는 DTO
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KakaoTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
 }

--- a/src/main/java/com/umc/timeto/auth/dto/kakao/KakaoUserInfo.java
+++ b/src/main/java/com/umc/timeto/auth/dto/kakao/KakaoUserInfo.java
@@ -1,0 +1,4 @@
+package com.umc.timeto.auth.dto.kakao;
+
+public class KakaoUserInfo {
+}

--- a/src/main/java/com/umc/timeto/auth/dto/kakao/KakaoUserInfo.java
+++ b/src/main/java/com/umc/timeto/auth/dto/kakao/KakaoUserInfo.java
@@ -1,4 +1,14 @@
 package com.umc.timeto.auth.dto.kakao;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// 카카오 API 응답을 서비스에서 사용하기 쉽게 변환한 사용자 정보 DTO
+@Getter
+@AllArgsConstructor
 public class KakaoUserInfo {
+
+    private Long kakaoId;
+    private String email;
+    private String name;
 }

--- a/src/main/java/com/umc/timeto/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/umc/timeto/auth/jwt/JwtProvider.java
@@ -1,0 +1,4 @@
+package com.umc.timeto.auth.jwt;
+
+public class JwtProvider {
+}

--- a/src/main/java/com/umc/timeto/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/umc/timeto/auth/jwt/JwtProvider.java
@@ -1,4 +1,53 @@
 package com.umc.timeto.auth.jwt;
 
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
 public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    @Value("${jwt.access-exp-seconds}")
+    private long accessExpSeconds;
+
+    @Value("${jwt.refresh-exp-seconds}")
+    private long refreshExpSeconds;
+
+    private Key signingKey;
+
+    @PostConstruct
+    public void init() {
+        signingKey = Keys.hmacShaKeyFor(jwtSecret.getBytes());
+    }
+
+    // access token 발급
+    public String createAccessToken(Long memberId) {
+        return createToken(memberId, accessExpSeconds);
+    }
+
+    // refresh token 발급
+    public String createRefreshToken(Long memberId) {
+        return createToken(memberId, refreshExpSeconds);
+    }
+
+    private String createToken(Long memberId, long expSeconds) {
+        Date now = new Date();
+        Date exp = new Date(now.getTime() + (expSeconds * 1000L));
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(memberId))
+                .setIssuedAt(now)
+                .setExpiration(exp)
+                .signWith(signingKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
 }

--- a/src/main/java/com/umc/timeto/auth/service/AuthService.java
+++ b/src/main/java/com/umc/timeto/auth/service/AuthService.java
@@ -1,0 +1,4 @@
+package com.umc.timeto.auth.service;
+
+public class AuthService {
+}

--- a/src/main/java/com/umc/timeto/auth/service/AuthService.java
+++ b/src/main/java/com/umc/timeto/auth/service/AuthService.java
@@ -1,4 +1,65 @@
 package com.umc.timeto.auth.service;
 
+import com.umc.timeto.auth.client.KakaoClient;
+import com.umc.timeto.auth.dto.KakaoLoginResponse;
+import com.umc.timeto.auth.dto.kakao.KakaoUserInfo;
+import com.umc.timeto.auth.jwt.JwtProvider;
+import com.umc.timeto.member.entity.Member;
+import com.umc.timeto.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
 public class AuthService {
+
+    private final KakaoClient kakaoClient;
+    private final MemberRepository memberRepository;
+    private final JwtProvider jwtProvider;
+
+    // 카카오 로그인(신규면 회원 생성)
+    @Transactional
+    public LoginResult kakaoLogin(String authorizationCode) {
+
+        String kakaoAccessToken = kakaoClient.getAccessToken(authorizationCode);
+        KakaoUserInfo userInfo = kakaoClient.getUserInfo(kakaoAccessToken);
+
+        Optional<Member> existingMember = memberRepository.findByKakaoId(userInfo.getKakaoId());
+
+        boolean isNewMember;
+        Member member;
+
+        if (existingMember.isPresent()) {
+            member = existingMember.get();
+            isNewMember = false;
+        } else {
+            member = memberRepository.save(
+                    Member.createKakaoMember(
+                            userInfo.getKakaoId(),
+                            userInfo.getEmail(),
+                            userInfo.getName()
+                    )
+            );
+            isNewMember = true;
+        }
+
+        String accessToken = jwtProvider.createAccessToken(member.getMemberId());
+        String refreshToken = jwtProvider.createRefreshToken(member.getMemberId());
+
+        KakaoLoginResponse response = new KakaoLoginResponse(
+                member.getMemberId(),
+                accessToken,
+                refreshToken
+        );
+
+        return new LoginResult(response, isNewMember);
+    }
+
+    public record LoginResult(
+            KakaoLoginResponse response,
+            boolean isNewMember
+    ) { }
 }

--- a/src/main/java/com/umc/timeto/global/apiPayload/code/ResponseCode.java
+++ b/src/main/java/com/umc/timeto/global/apiPayload/code/ResponseCode.java
@@ -7,7 +7,13 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 @Getter
 public enum ResponseCode {
-    ;
+    // Common
+    COMMON200(HttpStatus.OK, "요청에 성공하였습니다."),
+    COMMON201(HttpStatus.CREATED, "회원 가입 및 로그인 성공"),
+    COMMON400(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+
+    // Auth
+    AUTH_LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공하였습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/umc/timeto/global/apiPayload/dto/ResponseDTO.java
+++ b/src/main/java/com/umc/timeto/global/apiPayload/dto/ResponseDTO.java
@@ -2,12 +2,22 @@ package com.umc.timeto.global.apiPayload.dto;
 
 import com.umc.timeto.global.apiPayload.code.ResponseCode;
 import lombok.Data;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 
 @Data
 public class ResponseDTO<T> {
+
+    @Schema(description = "HTTP 상태 코드", example = "200")
     private Integer status;
+
+    @Schema(description = "응답 코드", example = "COMMON200")
     private String code;
+
+    @Schema(description = "응답 메시지", example = "요청에 성공하였습니다.")
     private String message;
+
+    @Schema(description = "응답 데이터")
     private T data;
 
     public ResponseDTO(ResponseCode responseCode, T data) {

--- a/src/main/java/com/umc/timeto/member/entity/Member.java
+++ b/src/main/java/com/umc/timeto/member/entity/Member.java
@@ -1,4 +1,32 @@
 package com.umc.timeto.member.entity;
+import jakarta.persistence.*;
+import lombok.*;
 
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member")
 public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "email", nullable = false, length = 100, unique = true)
+    private String email;
+
+    @Column(name = "kakao_id", unique = true)
+    private Long kakaoId;
+
+    public static Member createKakaoMember(Long kakaoId, String email, String name) {
+        Member member = new Member();
+        member.kakaoId = kakaoId;
+        member.email = email;
+        member.name = name;
+        return member;
+    }
 }

--- a/src/main/java/com/umc/timeto/member/entity/Member.java
+++ b/src/main/java/com/umc/timeto/member/entity/Member.java
@@ -1,0 +1,4 @@
+package com.umc.timeto.member.entity;
+
+public class Member {
+}

--- a/src/main/java/com/umc/timeto/member/repository/MemberRepository.java
+++ b/src/main/java/com/umc/timeto/member/repository/MemberRepository.java
@@ -1,0 +1,4 @@
+package com.umc.timeto.member.repository;
+
+public class MemberRepository {
+}

--- a/src/main/java/com/umc/timeto/member/repository/MemberRepository.java
+++ b/src/main/java/com/umc/timeto/member/repository/MemberRepository.java
@@ -1,4 +1,15 @@
 package com.umc.timeto.member.repository;
 
-public class MemberRepository {
+import com.umc.timeto.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    //카카오 아이디로 회원 조회
+    Optional<Member> findByKakaoId(Long kakaoId);
+
+    // 이메일로 회원 조회
+    Optional<Member> findByEmail(String email);
 }


### PR DESCRIPTION
### 📑 이슈 번호

- close #5

### ✨️ 작업 내용

- 카카오 OAuth 로그인 API 구현
- 카카오 사용자 정보 기반 회원 조회 및 신규 회원가입 처리
- Swagger를 통해 OAuth 플로우 정상 동작 확인


### 💭 코멘트

- 프론트 미연동 상태로 Swagger 기반 테스트를 진행했습니다.
- 프론트 연동 시 redirectUri 일치 여부만 확인하면 됩니다.